### PR TITLE
Disable creation of changenotes of pre-commit update.

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,5 +9,7 @@ jobs:
   pre-commit-update:
     name: Update pre-commit
     uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
+    with:
+      create-changenote: false
     secrets:
       BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "http://alastairs-place.net/projects/mac_alias"
-Source = "https://github.com/al45stair/mac_alias"
+Source = "https://github.com/dmgbuild/mac_alias"
 
 [project.scripts]
 mac_alias = "mac_alias.__main__:main"


### PR DESCRIPTION
Repo doesn't use towncrier, so there's no need for a change note.