### PR TITLE
Bump pre-commit-hooks from v4.6.0 to v5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,12 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
-    hooks:
-    - id: docformatter
-      args: [--in-place]
+  # Docformatter 1.7.5 isn't compatible with Pre-commit 4.0
+  # - repo: https://github.com/myint/docformatter
+  #   rev: v1.7.5
+  #   hooks:
+  #   - id: docformatter
+  #     args: [--in-place]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.8.0
     hooks:


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from v4.6.0 to v5.0.0 and ran the update against the repo.