### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,24 +52,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         macOS-version: [
             # x86_64 runners
-            "macos-12", "macos-13",
+            "macos-13",
             # M1 runners
             "macos-14"
           ]
         include:
           - experimental: false
 
-          - python-version: "3.13-dev"
+          - python-version: "3.13"
             experimental: true
 
         exclude:
-          # actions/setup-python doesn't provide Python3.8 or 3.9 for M1.
-          - macOS-version: "macos-14"
-            python-version : "3.8"
-
+          # actions/setup-python doesn't provide Python 3.9 for M1.
           - macOS-version: "macos-14"
             python-version : "3.9"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   # Docformatter 1.7.5 isn't compatible with Pre-commit 4.0
   # - repo: https://github.com/myint/docformatter
   #   rev: v1.7.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 name = "mac_alias"
 description = "Generate/parse macOS Alias records from Python"
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Alastair Houghton", email="alastair@alastairs-place.net"}
@@ -24,7 +24,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -47,9 +46,7 @@ mac_alias = "mac_alias.__main__:main"
 [project.optional-dependencies]
 dev = [
     "coverage == 7.6.1",
-    # Pre-commit 3.6.0 deprecated support for Python 3.8
-    "pre-commit == 3.5.0 ; python_version < '3.9'",
-    "pre-commit == 4.0.0 ; python_version >= '3.9'",
+    "pre-commit == 4.0.1",
     "pytest == 8.3.3",
     "pytest-cov == 5.0.0",
     "tox == 4.21.2",

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extend_ignore=C901,E203
 max-line-length = 119
 
 [tox]
-envlist = docs,package,py{38,39,310,311,312,313}
+envlist = docs,package,py{39,310,311,312,313}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 3.8 is now EOL, so we can drop support.

Also removing macOS-12 from the CI matrix, as we're less than 2 months from the runner being removed.