### PR TITLE
Bump pyupgrade from v3.19.0 to v3.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: [--py39-plus]


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.19.0 to v3.19.1 and ran the update against the repo.