### PR TITLE
Bump black-pre-commit-mirror from 24.10.0 to 25.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   #   - id: docformatter
   #     args: [--in-place]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.10.0 to 25.1.0 and ran the update against the repo.